### PR TITLE
add

### DIFF
--- a/src/components/AddCard/AddCard.js
+++ b/src/components/AddCard/AddCard.js
@@ -18,6 +18,7 @@ import {
   AddCardLabelText,
   AddCardOptionCont,
   AddCardSvgButtonText,
+  AddCardSvgClose,
   AddCardSvgContainer,
   AddCardTextCal,
   AddCardTextCont,
@@ -86,7 +87,11 @@ export const AddCard = ({ onCloseModal }) => {
       }}
     >
       <AddCardWrapper>
-        <CLoseButton onClick = {onCloseModal}>Close</CLoseButton>
+        <CLoseButton onClick = {onCloseModal}>
+          <AddCardSvgClose>
+          <use xlinkHref={`${sprite}#icon-x-close`}></use>
+          </AddCardSvgClose>
+          </CLoseButton>
         <AddCardContainer>
           <AddCardHeader>Add Card</AddCardHeader>
           <AddCardTextCont>

--- a/src/components/AddCard/AddCard.styled.js
+++ b/src/components/AddCard/AddCard.styled.js
@@ -268,3 +268,29 @@ padding: 0;
 margin: 0;
 
 `
+
+export const AddAnotherCard = styled.button`
+margin-top:14px;
+display: flex;
+align-items: center;
+justify-content: center;
+gap:8px;
+width: 100%;
+padding-top: 10px;
+padding-bottom: 10px;
+background-color: ${p => p.theme.violetColors.accentColor};
+border-radius:8px;
+border-color:transparent;
+font-size: 14px;
+font-weight: 500;
+line-height: 21px;
+letter-spacing: -2%;
+`
+
+export const AddCardSvgClose = styled.svg`
+fill: ${p => p.theme.colors.darkTextColor};
+  stroke: ${p => p.theme.colors.darkTextColor};
+  width: 18px;
+  height: 18px;
+
+`

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -1,6 +1,6 @@
 import { Outlet, useParams } from 'react-router-dom';
 import { Suspense } from 'react';
-import { useParams } from 'react-router-dom';
+// import { useParams } from 'react-router-dom';
 import RegisterForm from 'components/Register/RegisterForm';
 import {
   AuthLinks,

--- a/src/components/ColumnListItem/ColumnListItem.jsx
+++ b/src/components/ColumnListItem/ColumnListItem.jsx
@@ -15,6 +15,7 @@ import {
 
 import { AddColumnButton } from 'components/Button/AddColumnButton';
 import { AddCard } from 'components/AddCard/AddCard';
+import { AddAnotherCard,AddCardButtonSvg, AddCardSvgButtonText, AddCardSvgContainer } from 'components/AddCard/AddCard.styled';
 // import { useDispatch } from 'react-redux';
 Modal.setAppElement('#root');
 export const ColumnListItem = ({column: { _id, title}}) => {    
@@ -59,7 +60,14 @@ export const ColumnListItem = ({column: { _id, title}}) => {
          </ColumnHeader>          
             {/* <CardList columnId={id}/> */}
             {/* <AddColumnButton/> */}
-            <button  onClick={openModal}>AddAnotherCard</button>  
+            <AddAnotherCard onClick = {openModal} type="submit">
+          <AddCardSvgContainer>
+            <AddCardButtonSvg>
+              <use xlinkHref={`${sprite}#icon-plus`}></use>
+            </AddCardButtonSvg>
+          </AddCardSvgContainer>
+          <AddCardSvgButtonText>Add</AddCardSvgButtonText>
+        </AddAnotherCard> 
 
 
             <Modal


### PR DESCRIPTION
Prayer of invocation to the Holy Spirit for an ecclesial assembly of governance or discernment (thus synodal)
Every session of the Second Vatican Council began with the prayer Adsumus Sancte Spiritus, the first word of the Latin original meaning, “We stand before You, Holy Spirit,” which has been historically used at Councils, Synods and other Church gatherings for hundreds of years, being attributed to Saint Isidore of Seville (c. 560 - 4 April 636). As we are called to embrace this synodal path of the Synod 2021-2023, this prayer invites the Holy Spirit to operate within us so that we may be a community and a people of grace. For the Synod 2021-2023, we propose to use this simplified version, so that any group or liturgical assembly can pray more easily.


We stand before You, Holy Spirit,

  as we gather together in Your name.

With You alone to guide us,

  make Yourself at home in our hearts;

Teach us the way we must go

  and how we are to pursue it.

We are weak and sinful;

  do not let us promote disorder.

Do not let ignorance lead us down the wrong path

  nor partiality influence our actions.

Let us find in You our unity

  so that we may journey together to eternal life

  and not stray from the way of truth

  and what is right.

All this we ask of You,

  who are at work in every place and time,

  in the communion of the Father and the Son,

  forever and ever.